### PR TITLE
Fix arrow keys in IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,11 @@ function keyName(event) {
   // Edge sometimes produces wrong names (Issue #3)
   if (name == "Esc") name = "Escape"
   if (name == "Del") name = "Delete"
+  // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8860571/
+  if (name == "Left") name = "ArrowLeft"
+  if (name == "Up") name = "ArrowUp"
+  if (name == "Right") name = "ArrowRight"
+  if (name == "Down") name = "ArrowDown"
   return name
 }
 


### PR DESCRIPTION
> KeyboardEvent.key values returned by Edge for arrow keys are Down, Left, Right, Up, which are non-standard as W3C specifies ArrowDown, ArrowLeft, ArrowRight, ArrowUp. Chrome and Firefox return standard values.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8860571/