### PR TITLE
Reference TS declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Get a KeyboardEvent.key-style string from an event",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marijnh/w3c-keyname.git"


### PR DESCRIPTION
This is needed so that npm install automatically finds the types.