### PR TITLE
Add TypeScript types entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     "import": "./index.js",
-    "require": "./index.cjs"
+    "require": "./index.cjs",
+    "types": "./index.d.ts"
   },
   "module": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Exports field needs types definition for each entry in order to work correctly with bundler mode for typescript (tsconfig).

```
error TS7016: Could not find a declaration file for module 'w3c-keyname'. '/app/build/node_modules/w3c-keyname/index.es.js' implicitly has an 'any' type.
  There are types at '/app/node_modules/w3c-keyname/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'w3c-keyname' library may need to update its package.json or typings.

2 import { base } from 'w3c-keyname'
```